### PR TITLE
Hotfix, Metaconditions Causing Some Single Target Spells to have AoE

### DIFF
--- a/Editor/Mods/Pathfinder2ndEdition_dda83752-5c01-30f9-6a09-824c7e182090/Spell/MetaConditions.tbl
+++ b/Editor/Mods/Pathfinder2ndEdition_dda83752-5c01-30f9-6a09-824c7e182090/Spell/MetaConditions.tbl
@@ -17,7 +17,7 @@
         <field name="UUID" type="IdTableFieldDefinition" value="d6fe272c-29e2-492d-8509-05b4f038a78b" />
         <field name="Name" type="NameTableFieldDefinition" value="Slither_OnlyAttacks_AoE" />
         <field name="ConditionType" type="EnumerationTableFieldDefinition" value="AoE" enumeration_type_name="ConditionType" version="1" />
-        <field name="Filter" type="StringTableFieldDefinition" value="not HasStringInSpellRoll('Attack2e') and not SpellId('Target_EscapeSlither_Acrobatics') and not SpellId('Target_EscapeSlither_Athletics') and HasFunctor(StatsFunctorType.DealDamage)" />
+        <field name="Filter" type="StringTableFieldDefinition" value="HasAoEConditions() and not HasStringInSpellRoll('Attack2e') and not SpellId('Target_EscapeSlither_Acrobatics') and not SpellId('Target_EscapeSlither_Athletics') and HasFunctor(StatsFunctorType.DealDamage)" />
         <field name="AdditionalConditions" type="StringTableFieldDefinition" value="not Tagged('SLITHER_TENTACLE')" />
         <field name="OverrideOriginalCondition" type="BoolTableFieldDefinition" value="False" />
       </fields>

--- a/Public/Pathfinder2ndEdition_dda83752-5c01-30f9-6a09-824c7e182090/Spell/MetaConditions.lsx
+++ b/Public/Pathfinder2ndEdition_dda83752-5c01-30f9-6a09-824c7e182090/Spell/MetaConditions.lsx
@@ -15,7 +15,7 @@
                 <node id="MetaCondition">
                     <attribute id="AdditionalConditions" type="LSString" value="not Tagged(&apos;SLITHER_TENTACLE&apos;)"/>
                     <attribute id="ConditionType" type="FixedString" value="AoE"/>
-                    <attribute id="Filter" type="LSString" value="not HasStringInSpellRoll(&apos;Attack2e&apos;) and not SpellId(&apos;Target_EscapeSlither_Acrobatics&apos;) and not SpellId(&apos;Target_EscapeSlither_Athletics&apos;) and HasFunctor(StatsFunctorType.DealDamage)"/>
+                    <attribute id="Filter" type="LSString" value="HasAoEConditions() and not HasStringInSpellRoll(&apos;Attack2e&apos;) and not SpellId(&apos;Target_EscapeSlither_Acrobatics&apos;) and not SpellId(&apos;Target_EscapeSlither_Athletics&apos;) and HasFunctor(StatsFunctorType.DealDamage)"/>
                     <attribute id="Name" type="LSString" value="Slither_OnlyAttacks_AoE"/>
                     <attribute id="OverrideOriginalCondition" type="bool" value="false"/>
                     <attribute id="UUID" type="guid" value="d6fe272c-29e2-492d-8509-05b4f038a78b"/>


### PR DESCRIPTION
AoE meta condition for Slither was accidentally making lots of spells gain AoE conditions without a valid AoE radius, resulting in bad infinite range stuff.